### PR TITLE
Add Code of Conduct with Navigation

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,17 +1,19 @@
 {
     "type": "application",
-    "source-directories": ["src"],
+    "source-directories": [
+        "src"
+    ],
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
-            "elm/html": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/url": "1.0.0"
         },
         "indirect": {
             "elm/json": "1.1.2",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ module Main exposing (Model, Msg(..), codeOfConduct, init, main, update, view)
 import Browser exposing (UrlRequest)
 import Browser.Navigation
 import Html exposing (Html, a, div, h1, h2, h3, h5, img, main_, p, section, span, text)
-import Html.Attributes exposing (class, href, id, src)
+import Html.Attributes exposing (class, href, id, src, target)
 import Html.Events exposing (onClick)
 import Url exposing (Url)
 
@@ -93,18 +93,21 @@ mainContent =
             [ class "stay-tuned" ]
             [ h3
                 [ class "stay-tuned__coming-soon" ]
-                [ text "Speaker lineup and ticket sales"
+                [ text "More details "
                 , span [ class "gradient-anim" ] [ text " coming soon!" ]
                 ]
             , div
                 [ class "footer" ]
-                [ a
-                    [ href "https://2019.elminthespring.org/" ]
-                    [ text "2019 Site" ]
+                [ a [ href "https://www.papercall.io/elm-in-the-spring-2020", target "_blank" ]
+                    [ text "CFP" ]
                 , text " | "
                 , a
                     [ onClick (NavigateTo codeOfConductPath), href codeOfConductPath ]
                     [ text "Code of Conduct" ]
+                , text " | "
+                , a
+                    [ href "https://2019.elminthespring.org/", target "_blank" ]
+                    [ text "2019 Site" ]
                 ]
             ]
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,20 +1,26 @@
-module Main exposing (..)
+module Main exposing (Model, Msg(..), codeOfConduct, init, main, update, view)
 
-import Browser
-import Html exposing (Html, text, span, div, h1, img, section, main_, h2, h3)
-import Html.Attributes exposing (src, class)
+import Browser exposing (UrlRequest)
+import Browser.Navigation
+import Html exposing (Html, a, div, h1, h2, h3, h5, img, main_, p, section, span, text)
+import Html.Attributes exposing (class, href, id, src)
+import Html.Events exposing (onClick)
+import Url exposing (Url)
+
 
 
 ---- MODEL ----
 
 
 type alias Model =
-    {}
+    { navigationKey : Browser.Navigation.Key
+    , url : Url
+    }
 
 
-init : ( Model, Cmd Msg )
-init =
-    ( {}, Cmd.none )
+init : () -> Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
+init _ url key =
+    ( { navigationKey = key, url = url }, Cmd.none )
 
 
 
@@ -22,52 +28,118 @@ init =
 
 
 type Msg
-    = NoOp
+    = OnUrlRequest UrlRequest
+    | OnUrlChange Url
+    | NavigateTo String
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    ( model, Cmd.none )
+    case msg of
+        OnUrlRequest _ ->
+            ( model, Cmd.none )
+
+        OnUrlChange url ->
+            ( { model | url = url }, Cmd.none )
+
+        NavigateTo url ->
+            ( model, Browser.Navigation.pushUrl model.navigationKey url )
 
 
 
 ---- VIEW ----
 
 
+codeOfConductPath : String
+codeOfConductPath =
+    "/code-of-conduct"
+
+
 view : Model -> Html Msg
 view model =
+    if model.url.path == codeOfConductPath then
+        codeOfConduct
+
+    else
+        mainContent
+
+
+mainContent : Html Msg
+mainContent =
     main_
-        []
+        [ id "splash-page" ]
         [ section
             [ class "intro" ]
             [ div
                 [ class "intro__logo--flower" ]
-                [ img [ src "%PUBLIC_URL%/images/eits-logo-flower.svg"  ] [] ]
+                [ img [ src "%PUBLIC_URL%/images/eits-logo-flower.svg" ] [] ]
             , div
                 [ class "intro__logo--text" ]
                 [ img [ src "%PUBLIC_URL%/images/eits-logo-text.svg" ] [] ]
             , div
                 [ class "intro__details" ]
-                [  h2
+                [ h2
                     [ class "intro__date" ]
-                    [ span [] [text "May 1, 2020"]
-                    , span [] [text "\u{00A0}🌸\u{00A0}"]
-                    , span [] [text "Chicago, IL"]
+                    [ span [] [ text "May 1, 2020" ]
+                    , span [] [ text "\u{00A0}🌸\u{00A0}" ]
+                    , span [] [ text "Chicago, IL" ]
                     ]
                 , div
-                    [ class "intro__tagline" ] [ text "A day to learn, teach, and share about Elm!" ]
+                    [ class "intro__tagline" ]
+                    [ text "A day to learn, teach, and share about Elm!" ]
                 ]
             ]
         , section
             [ class "stay-tuned" ]
-            [ h3 
-                [ class "stay-tuned__coming-soon" ] 
-                [ text "Speaker lineup and ticket sales" 
-                , span [ class "gradient-anim"] [ text " coming soon!" ]
+            [ h3
+                [ class "stay-tuned__coming-soon" ]
+                [ text "Speaker lineup and ticket sales"
+                , span [ class "gradient-anim" ] [ text " coming soon!" ]
+                ]
+            , div
+                [ class "footer" ]
+                [ a
+                    [ href "https://2019.elminthespring.org/" ]
+                    [ text "2019 Site" ]
+                , text " | "
+                , a
+                    [ onClick (NavigateTo codeOfConductPath), href codeOfConductPath ]
+                    [ text "Code of Conduct" ]
                 ]
             ]
         ]
 
+
+codeOfConduct : Html Msg
+codeOfConduct =
+    main_ [ id "code-of-conduct" ]
+        [ h1 [ id "conference-code-of-conduct" ] [ text "Conference Code of Conduct" ]
+        , p []
+            [ a [ onClick (NavigateTo "/"), href "/" ] [ text "back" ]
+            ]
+        , p [] [ text "All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody." ]
+        , h2 [ id "need-help" ] [ text "Need Help?" ]
+        , p []
+            [ text "In advance of the conference, please contact the organizing team at "
+            , a [ href "mailto:hello@elminthespring.org" ] [ text "hello@elminthespring.org" ]
+            , text " any time you need help or have questions or concerns. In the weeks before the conference, we’ll send out direct contact info for the organizers so you can reach out to us in real time via text, phone, or Twitter."
+            ]
+        , h2 [ id "the-quick-version" ] [ text "The Quick Version" ]
+        , p [] [ text "Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organisers." ]
+        , h2 [ id "the-less-quick-version" ] [ text "The Less Quick Version" ]
+        , p [] [ text "Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. " ]
+        , p [] [ text "Participants asked to stop any harassing behavior are expected to comply immediately. " ]
+        , p [] [ text "Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment. " ]
+        , p [] [ text "If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund. " ]
+        , p []
+            [ text "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately." ]
+        , p [] [ text " Conference staff can be identified as they&#39;ll be wearing branded clothing and/or badges. " ]
+        , p [] [ text "Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance. " ]
+        , p [] [ text "We expect participants to follow these rules at conference and workshop venues and conference-related social events." ]
+        , p []
+            [ a [ onClick (NavigateTo "/"), href "/" ] [ text "back" ]
+            ]
+        ]
 
 
 
@@ -76,9 +148,15 @@ view model =
 
 main : Program () Model Msg
 main =
-    Browser.element
-        { view = view
-        , init = \_ -> init
+    Browser.application
+        { view =
+            \model ->
+                { title = "Elm in the Spring"
+                , body = [ view model ]
+                }
+        , init = init
         , update = update
         , subscriptions = always Sub.none
+        , onUrlRequest = OnUrlRequest
+        , onUrlChange = OnUrlChange
         }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -42,8 +42,8 @@ update msg model =
         OnUrlChange url ->
             ( { model | url = url }, Cmd.none )
 
-        NavigateTo url ->
-            ( model, Browser.Navigation.pushUrl model.navigationKey url )
+        NavigateTo urlString ->
+            ( model, Browser.Navigation.pushUrl model.navigationKey urlString )
 
 
 

--- a/src/main.css
+++ b/src/main.css
@@ -47,56 +47,65 @@ img {
   max-width: 100%;
   height: auto; }
 
-main {
+#splash-page {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   align-items: center;
   height: 100vh;
   min-height: 100vh; }
-
-.intro {
-  padding: 2rem;
-  align-self: normal;
-  color: var(--theme-on-primary);
-  background: var(--theme-primary);
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-gap: 0.8em; }
-  .intro__logo--flower {
-    align-self: end;
-    padding-left: 20px; }
-  .intro__logo--text {
-    grid-column: span 2;
-    align-self: end;
-    padding-right: 20px; }
-  .intro__details {
-    grid-column: span 3;
-    padding: 0 0.4rem; }
-  .intro__date {
-    font-size: 2rem;
-    letter-spacing: 0.1em;
-    font-family: var(--theme-font-family-display);
-    color: var(--theme-secondary);
-    margin: 10px auto;
+  #splash-page .intro {
+    padding: 2rem;
+    align-self: normal;
+    color: var(--theme-on-primary);
+    background: var(--theme-primary);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 0.8em; }
+    #splash-page .intro__logo--flower {
+      align-self: end;
+      padding-left: 20px; }
+    #splash-page .intro__logo--text {
+      grid-column: span 2;
+      align-self: end;
+      padding-right: 20px; }
+    #splash-page .intro__details {
+      grid-column: span 3;
+      padding: 0 0.4rem; }
+    #splash-page .intro__date {
+      font-size: 2rem;
+      letter-spacing: 0.1em;
+      font-family: var(--theme-font-family-display);
+      color: var(--theme-secondary);
+      margin: 10px auto;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center; }
+    #splash-page .intro__tagline {
+      font-size: 1.3rem;
+      grid-column: span 3;
+      text-align: center;
+      margin: 0 auto; }
+  #splash-page .stay-tuned {
+    color: var(--theme-on-secondary);
+    background: var(--theme-secondary);
+    align-self: normal;
+    padding: 2rem;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     justify-content: center; }
-  .intro__tagline {
-    font-size: 1.3rem;
-    grid-column: span 3;
+    #splash-page .stay-tuned__coming-soon {
+      font-size: 3.5rem; }
+  #splash-page .footer {
     text-align: center;
-    margin: 0 auto; }
+    position: absolute;
+    bottom: 10px; }
+    #splash-page .footer a {
+      color: var(--theme-on-secondary); }
 
-.stay-tuned {
-  color: var(--theme-on-secondary);
+#code-of-conduct {
   background: var(--theme-secondary);
-  align-self: normal;
-  padding: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center; }
-  .stay-tuned__coming-soon {
-    font-size: 3.5rem; }
+  color: var(--theme-on-secondary);
+  padding: 20px; }
 
 .gradient-anim {
   background: linear-gradient(to right, var(--theme-on-secondary) 20%, #449dd5 40%, #449dd5 60%, var(--theme-on-secondary) 80%);

--- a/src/main.scss
+++ b/src/main.scss
@@ -34,73 +34,87 @@ img {
 }
 
 // *************************
-
-main {
+#splash-page {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   align-items: center;
   height: 100vh;
   min-height: 100vh;
-}
 
-.intro {
-  padding: 2rem;
-  align-self: normal;
-  color: theme-var($--theme-on-primary);
-  background: theme-var($--theme-primary);
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-gap: 0.8em;
+  .intro {
+    padding: 2rem;
+    align-self: normal;
+    color: theme-var($--theme-on-primary);
+    background: theme-var($--theme-primary);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 0.8em;
 
-  &__logo {
-    &--flower {
-      align-self: end;
-      padding-left: 20px;
+    &__logo {
+      &--flower {
+        align-self: end;
+        padding-left: 20px;
+      }
+
+      &--text {
+        grid-column: span 2;
+        align-self: end;
+        padding-right: 20px;
+      }
     }
 
-    &--text {
-      grid-column: span 2;
-      align-self: end;
-      padding-right: 20px;
+    &__details {
+      grid-column: span 3;
+      padding: 0 0.4rem;
+    }
+
+    &__date {
+      font-size: 2rem;
+      letter-spacing: 0.1em;
+      font-family: theme-var($--theme-font-family-display);
+      color: theme-var($--theme-secondary);
+      margin: 10px auto;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    &__tagline {
+      font-size: 1.3rem;
+      grid-column: span 3;
+      text-align: center;
+      margin: 0 auto;
     }
   }
 
-  &__details {
-    grid-column: span 3;
-    padding: 0 0.4rem;
-  }
-
-  &__date {
-    font-size: 2rem;
-    letter-spacing: 0.1em;
-    font-family: theme-var($--theme-font-family-display);
-    color: theme-var($--theme-secondary);
-    margin: 10px auto;
-    display: flex;
-    flex-wrap: wrap;
+  .stay-tuned {
+    color: theme-var($--theme-on-secondary);
+    background: theme-var($--theme-secondary);
+    align-self: normal;
+    padding: 2rem;
+    display: flex; align-items: center;
     justify-content: center;
+
+    &__coming-soon {
+      font-size: 3.5rem;
+    }
   }
 
-  &__tagline {
-    font-size: 1.3rem;
-    grid-column: span 3;
+  .footer {
     text-align: center;
-    margin: 0 auto;
+    position: absolute;
+    bottom: 10px;
+
+    a {
+      color: theme-var($--theme-on-secondary);
+    }
   }
 }
 
-.stay-tuned {
-  color: theme-var($--theme-on-secondary);
+#code-of-conduct {
   background: theme-var($--theme-secondary);
-  align-self: normal;
-  padding: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &__coming-soon {
-    font-size: 3.5rem;
-  }
+  color: theme-var($--theme-on-secondary);
+  padding: 20px;
 }
 
 .gradient-anim {


### PR DESCRIPTION
Now that we have a Code of Conduct, let's add it to the initial splash page as we prepare the full site. (While we're at it, we might as well add the link to the 2019 site as well and a link to the CFP, so people can find it from the site.)

This PR expands the Elm app to use (very basic) Elm navigation per [the Elm Browser package docs](https://package.elm-lang.org/packages/elm/browser/latest/) -- no route type, just tracking the raw URL and checking to see whether it matches `/code-of-conduct`. (As we build out the full site we can expand on this.)
